### PR TITLE
Get total number of commits this month

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -9,15 +9,15 @@
     </div>
     <div class="col-xs-12 col-md-3">
       <a href="https://github.com/chrisvogt" class="btn btn-stats btn-block hvr-grow-shadow">
-        <p>
-          <span class="lead"><i class="fa fa-code-fork"></i> 124 commits</span> <small>pushed to open source projects this month.</small>
+        <p id="stats-commits">
+          <span class="lead"><i class="fa fa-code-fork"></i> <span class="val"><img src="/img/ajax-loader.gif" alt="Loading icon..."></span> commits</span> <small>pushed to open source projects this month.</small>
         </p>
       </a>
     </div>
     <div class="col-xs-12 col-md-3">
       <a href="http://sandbox.chrisvogt.me" class="btn btn-stats btn-block hvr-grow-shadow">
         <p id="stats-projects">
-          <span class="lead"><i class="fa fa-cube"></i> <span class="val"><img src="/img/ajax-loader.gif"></span> projects</span> <small>available through my open source projects directory.</small>
+          <span class="lead"><i class="fa fa-cube"></i> <span class="val"><img src="/img/ajax-loader.gif" alt="Loading icon..."></span> projects</span> <small>available through my open source projects directory.</small>
         </p>
       </a>
     </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -22,30 +22,8 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
     <script src="/components/bootstrap/dist/js/bootstrap.min.js"></script>
     <script src="/components/jPages/js/jPages.min.js"></script>
+    <script src="/js/common.js"></script>
     <script>
-    $(function(){
-      $("div.jHolder").jPages({
-          containerID : "articles",
-          animation   : "flipInX",
-          pause       : 8500,
-          clickStop   : true,
-          scrollBrowse: true,
-          perPage     : 5,
-          previous    : ".previous a",
-          next        : ".next a",
-          links       : "blank",
-          first       : false,
-          last        : false
-      });
-      $.ajax({
-          type: "GET",
-          dataType: "json",
-          url: "https://projects.chrisvogt.me/api/1.0/all.json",
-          success: function (data) {
-              $('#stats-projects .val').html(data.projects.length);
-          }
-      });
-    });
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)

--- a/js/common.js
+++ b/js/common.js
@@ -1,0 +1,76 @@
+/**
+ * Extract and tally all public commits made to GitHub this month for a user.
+ * @author CJ Vogt <mail@chrisvogt.me>
+ */
+$(function() {
+    $("div.jHolder").jPages({ /** Initialize jQuery pagination plugin. */
+        containerID : "articles",
+        animation   : "flipInX",
+        pause       : 8500,
+        clickStop   : true,
+        scrollBrowse: true,
+        perPage     : 5,
+        previous    : ".previous a",
+        next        : ".next a",
+        links       : "blank",
+        first       : false,
+        last        : false
+    });
+
+    $.ajax({ /** Queries the chrisvogt/projects API. */
+        type: "GET",
+        dataType: "json",
+        url: "https://projects.chrisvogt.me/api/1.0/all.json",
+        success: function (data) {
+            $('#stats-projects .val').html(data.projects.length);
+        }
+    });
+
+    /**
+     * Contains GitHub User PushEvents
+     * @type {object}
+     */
+    var PushEvents;
+
+    /**
+     * Tallies the total number of commits.
+     * @type {number}
+     */
+    var commitCount = 0;
+
+    $.ajax({ /* Queries GitHub API for public users events. */
+        type: "GET",
+        dataType: "json",
+        url: "https://api.github.com/users/chrisvogt/events/public",
+        success: function(data) {
+            PushEvents = data.filter(filterByType);
+            $('#stats-commits .val').html(commitCount);
+        }
+    });
+
+    /**
+     * Filter - only return `PushEvents` containing at least one commit.
+     * @param {object} PushEvent - A GitHub PushEvent
+     * @returns {boolean}
+     */
+    function filterByType(obj) {
+        /**
+         * The current date.
+         * @property {object} Date
+         */
+        var today = new Date();
+
+        /**
+         * The first day of the current month.
+         * @property {object} Date
+         */
+        var firstOfMonth = new Date(today.getFullYear(), today.getMonth(), 1);
+        if ('type' in obj && typeof(obj.type) === 'string' && obj.type == 'PushEvent' && obj.payload.commits.length >= 1 && 'created_at' in obj && new Date(obj.created_at) > firstOfMonth) {
+            commitCount += obj.payload.commits.length;
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+})


### PR DESCRIPTION
Uses jQuery to make an AJAX request to the GitHub web API for a tally of the number of commits made on public projects for the current month. This is work towards #1.